### PR TITLE
Add XPath support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,5 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+.vscode/

--- a/declxml.py
+++ b/declxml.py
@@ -180,7 +180,8 @@ def array(item_processor, alias=None, nested=None, omit_empty=False):
         If not specified, then the name of the item processor is used instead.
     :param nested: If the array is a nested array, then this should be the name of
         the element under which all array items are located. If not specified, then
-        the array is treated as an embedded array.
+        the array is treated as an embedded array. Can also be specified using supported
+        XPath syntax.
     :param omit_empty: If True, then nested arrays will be omitted when serializing if
         they are empty. Only valid when nested is specified. Note that an empty array
         may only be omitted if it is not itself contained within an array. That is,
@@ -197,7 +198,8 @@ def boolean(element_name, attribute=None, required=True, alias=None, default=Fal
     """
     Creates a processor for boolean values.
 
-    :param element_name: Name of the XML element containing the value
+    :param element_name: Name of the XML element containing the value. Can also be specified
+        using supported XPath syntax.
     :param attribute: If specified, then the value is searched for under the
         attribute within the element specified by element_name. If not specified,
         then the value is searched for as the contents of the element specified by
@@ -220,7 +222,8 @@ def dictionary(element_name, children, required=True, alias=None):
     """
     Creates a processor for dictionary values.
 
-    :param element_name: Name of the XML element containing the dictionary value.
+    :param element_name: Name of the XML element containing the dictionary value. Can also be
+        specified using supported XPath syntax.
     :param children: List of declxml processor objects for processing the children
         contained within the dictionary.
     :param required: Indicates whether the value is required when parsing and serializing.

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -371,6 +371,124 @@ Processors can be composed to define more complex document structures.
     }
 
 
+XPath Syntax
+------------
+declxml supports a very small subset of XPath syntax that enables greater expressiveness when defining processors.
+
+The Dot (.) Selector
+""""""""""""""""""""
+The dot (.) selector can be used in a processor to refer to the containing processor's element. For instance, the dot operator can
+be used to refer to attributes on a childless element.
+
+.. sourcecode:: py
+
+    import declxml as xml
+
+    books_xml = """
+    <books>
+        <book title="I, Robot" author="Isaac Asimov" />
+        <book title="Foundation" author="Isaac Asimov" />
+        <book title="Nemesis" author="Isaac Asimov" />
+    </books>
+    """
+
+    books_processor = xml.array(xml.dictionary('book', [
+        xml.string('.', attribute='title'),  # Select the attribute "title" on the element "book"
+        xml.string('.', attribute='author'),
+    ]), nested='books')
+
+
+    xml.parse_from_string(books_processor, books_xml)
+    [
+        {'author': 'Isaac Asimov', 'title': 'I, Robot'},
+        {'author': 'Isaac Asimov', 'title': 'Foundation'},
+        {'author': 'Isaac Asimov', 'title': 'Nemesis'}
+    ]
+
+
+The dot operator can also be used to group an element's attribute values with the values of the element's children
+
+.. sourcecode:: py
+
+    import declxml as xml
+
+    author_xml = """
+    <author name="Liu Cixin">
+        <book>The Three Body Problem</book>
+        <book>The Dark Forest</book>
+        <book>Deaths End</book>
+    </author>
+    """
+
+    author_processor = xml.dictionary('author', [
+        xml.string('.', attribute='name'),
+        xml.array(xml.string('book'), alias='books')
+    ])
+
+    xml.parse_from_string(author_processor, author_xml)
+    {
+        'name': 'Liu Cixin',
+        'books': ['The Three Body Problem', 'The Dark Forest', "Deaths End"],
+    }
+
+The Path (/) Selector
+"""""""""""""""""""""
+The path selector (/) can be used to select descendant elements which can be useful for flattening out deeply nested XML data.
+
+.. sourcecode:: py
+
+    import declxml as xml
+
+    hugo_xml = """
+    <awards>
+        <hugo>
+            <winners>
+                <winner>
+                    <year>2017</year>
+                    <book>
+                        <title>The Obelisk Gate</title>
+                        <author>N. K. Jemisin</author>
+                    </book>
+                </winner>
+                <winner>
+                    <year>2016</year>
+                    <book>
+                        <title>The Fifth Season</title>
+                        <author> N.K. Jemisin</author>
+                    </book>
+                </winner>
+                <winner>
+                    <year>2015</year>
+                    <book>
+                        <title>The Three Body Problem</title>
+                        <author>Liu Cixin</author>
+                    </book>
+                </winner>
+            </winners>
+        </hugo>
+    </awards>
+    """
+
+    hugo_processor = xml.array(xml.dictionary('winner', [
+        xml.integer('year'),
+        xml.string('book/title', alias='title'),
+        xml.string('book/author', alias='author'),
+    ]), nested='awards/hugo/winners')
+
+    xml.parse_from_string(hugo_processor, hugo_xml)
+    [
+        {'author': 'N. K. Jemisin', 'title': 'The Obelisk Gate', 'year': 2017},
+        {'author': 'N.K. Jemisin', 'title': 'The Fifth Season', 'year': 2016},
+        {'author': 'Liu Cixin', 'title': 'The Three Body Problem', 'year': 2015}
+    ]
+
+The data will be serialized back into the deeply nested XML structure if the processor is used to perform serialization.
+
+It is *highly* recommended to provide aliases when using XPath syntax to ensure that when a value is parsed and assigned a
+name (e.g. a field of a dictionary, object, or namedtuple), the name of the value is a valid Python identifier without any
+'.' or '/' characters.
+
+
 User-Defined Classes
 --------------------
 Processors can also be created for parsing and serializing XML data to and from user-defined classes.

--- a/tests/test_xpath.py
+++ b/tests/test_xpath.py
@@ -1,0 +1,211 @@
+"""Contains unit tests for handling XPath syntax in processors"""
+import declxml as xml
+from .helpers import strip_xml
+
+
+class TestDot(object):
+    """Parse/serialize with dot specifier"""
+
+    _xml_string = strip_xml("""
+    <files>
+        <file name="a.txt" size="236" />
+        <file name="b.txt" size="7654" />
+    </files>
+    """)
+
+    _value = [
+        {
+            'name': 'a.txt',
+            'size': 236,
+        },
+        {
+            'name': 'b.txt',
+            'size': 7654,
+        }
+    ]
+
+    _processor = xml.array(xml.dictionary('file', [
+        xml.string('.', attribute='name'),
+        xml.integer('.', attribute='size')
+    ]), nested='files')
+
+    def test_parse_dot(self):
+        """Parse with dot specifier"""
+        actual_value = xml.parse_from_string(TestDot._processor, TestDot._xml_string)
+
+        assert TestDot._value == actual_value
+
+    def test_serialize_dot(self):
+        """Serialize with dot specifier"""
+        actual_xml_string = xml.serialize_to_string(TestDot._processor, TestDot._value)
+
+        assert TestDot._xml_string == actual_xml_string
+
+
+class TestMixed(object):
+    """Process with a mix of specifiers"""
+
+    _xml_string = strip_xml("""
+    <location name="Kansas City">
+        <coordinates>
+            <lat>39.0997</lat>
+            <lon>94.5786</lon>
+        </coordinates>
+    </location>
+    """)
+
+    _value = {
+        'name': 'Kansas City',
+        'lat': 39.0997,
+        'lon': 94.5786,
+    }
+
+    _processor = xml.dictionary('location', [
+        xml.string('.', attribute='name'),
+        xml.floating_point('coordinates/lat', alias='lat'),
+        xml.floating_point('coordinates/lon', alias='lon')
+    ])
+
+    def test_parse_mixed(self):
+        """Parse mix of specifiers"""
+        actual_value = xml.parse_from_string(TestMixed._processor, TestMixed._xml_string)
+
+        assert TestMixed._value == actual_value
+
+    def test_serialize_mixed(self):
+        """Serialize mix of specifiers"""
+        actual_xml_string = xml.serialize_to_string(TestMixed._processor, TestMixed._value)
+
+        assert TestMixed._xml_string == actual_xml_string
+
+
+class TestNestedSlash(object):
+    """Process with nested slash specifiers"""
+
+    _xml_string = strip_xml("""
+    <root>
+        <place>
+            <city>
+                <name>Kansas City</name>
+                <location>
+                    <coordinates>
+                        <lat>39.0997</lat>
+                        <lon>94.5786</lon>
+                    </coordinates>
+                </location>
+            </city>
+        </place>
+    </root>
+    """)
+
+    _value = {
+        'name': 'Kansas City',
+        'lat': 39.0997,
+        'lon': 94.5786,
+    }
+
+    _processor = xml.dictionary('root', [
+        xml.string('place/city/name', alias='name'),
+        xml.floating_point('place/city/location/coordinates/lat', alias='lat'),
+        xml.floating_point('place/city/location/coordinates/lon', alias='lon')
+    ])
+
+    def test_parse_nested_slash(self):
+        """Parse with nested slashes"""
+        actual_value = xml.parse_from_string(TestNestedSlash._processor,
+                                             TestNestedSlash._xml_string)
+
+        assert TestNestedSlash._value == actual_value
+
+    def test_serialize_nested_slash(self):
+        """Serialize with nested slashes"""
+        actual_xml_string = xml.serialize_to_string(TestNestedSlash._processor,
+                                                    TestNestedSlash._value)
+
+        assert TestNestedSlash._xml_string == actual_xml_string
+
+
+class TestSlash(object):
+    """Process with slash specifier"""
+
+    _xml_string = strip_xml("""
+    <city>
+        <name>Kansas City</name>
+        <coordinates>
+            <lat>39.0997</lat>
+            <lon>94.5786</lon>
+        </coordinates>
+    </city>
+    """)
+
+    _value = {
+        'name': 'Kansas City',
+        'lat': 39.0997,
+        'lon': 94.5786,
+    }
+
+    _processor = xml.dictionary('city', [
+        xml.string('name'),
+        xml.floating_point('coordinates/lat', alias='lat'),
+        xml.floating_point('coordinates/lon', alias='lon')
+    ])
+
+    def test_parse_slash(self):
+        """Parse with slash specifier"""
+        actual_value = xml.parse_from_string(TestSlash._processor, TestSlash._xml_string)
+
+        assert TestSlash._value == actual_value
+
+    def test_serialize_slash(self):
+        """Serialize with slash specifier"""
+        actual_xml_string = xml.serialize_to_string(TestSlash._processor, TestSlash._value)
+
+        assert TestSlash._xml_string == actual_xml_string
+
+
+class TestSlashFromRoot(object):
+    """Process with a slash starting from the root element"""
+
+    _xml_string = strip_xml("""
+    <locations>
+        <cities>
+            <city name="Kansas City" state="MO" />
+            <city name="Lincoln" state="NE" />
+            <city name="Salt Lake City" state="UT" />
+        </cities>
+    </locations>
+    """)
+
+    _value = [
+        {
+            'name': 'Kansas City',
+            'state': 'MO'
+        },
+        {
+            'name': 'Lincoln',
+            'state': 'NE'
+        },
+        {
+            'name': 'Salt Lake City',
+            'state': 'UT'
+        }
+    ]
+
+    _processor = xml.array(xml.dictionary('city', [
+        xml.string('.', attribute='name'),
+        xml.string('.', attribute='state'),
+    ]), nested='locations/cities', alias='cities')
+
+    def test_parse_slash_from_root(self):
+        """Parse with slash from root"""
+        actual_value = xml.parse_from_string(TestSlashFromRoot._processor,
+                                             TestSlashFromRoot._xml_string)
+
+        assert TestSlashFromRoot._value == actual_value
+
+    def test_serialize_slash_from_root(self):
+        """Serialize with slash from root"""
+        actual_xml_string = xml.serialize_to_string(TestSlashFromRoot._processor,
+                                                    TestSlashFromRoot._value)
+
+        assert TestSlashFromRoot._xml_string == actual_xml_string


### PR DESCRIPTION
Adds support for using a subset of the [XPath syntax](https://docs.python.org/2/library/xml.etree.elementtree.html#supported-xpath-syntax) supported by ElementTree when defining processors. Resolves #2.