### PR TITLE
WIP: Use lxml

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [packages]
 typing = "*"
+lxml = "*"
 
 [dev-packages]
 pytest = "==3.8.0"
@@ -15,7 +16,7 @@ coverage = "*"
 sphinx = "*"
 "doc8" = "*"
 codecov = "*"
-cosmic-ray-pytest-runner = {version = "*", python_version = ">= '3.6'"}
-cosmic-ray = {version = "*", python_version = ">= '3.6'"}
+cosmic-ray-pytest-runner = {version = "*",python_version = ">= '3.6'"}
+cosmic-ray = {version = "*",python_version = ">= '3.6'"}
 attrs = "*"
-mypy = {version = "==0.630", python_version = ">= '3.6'"}
+mypy = {version = "==0.630",python_version = ">= '3.6'"}

--- a/declxml.py
+++ b/declxml.py
@@ -68,7 +68,7 @@ from typing import (  # noqa pylint: disable=unused-import
 )
 import warnings
 from xml.dom import minidom  # type: ignore
-import xml.etree.ElementTree as ET
+from lxml import etree as ET
 
 
 _PY2 = sys.version_info[0] == 2

--- a/tests/test_hooks_value_transforms.py
+++ b/tests/test_hooks_value_transforms.py
@@ -493,7 +493,7 @@ def test_primitive_transform_attribute():
     """Transform a primitive value that is an attribute"""
     xml_string = strip_xml("""
     <data>
-        <element value="3" />
+        <element value="3"/>
     </data>
     """)
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -112,7 +112,7 @@ def test_array_serialize_array_of_arrays_omit_empty():
             <value>2</value>
             <value>4</value>
         </test-run>
-        <test-run />
+        <test-run/>
         <test-run>
             <value>12</value>
             <value>32</value>
@@ -123,7 +123,6 @@ def test_array_serialize_array_of_arrays_omit_empty():
     """)
 
     actual = xml.serialize_to_string(processor, value)
-
     assert expected == actual
 
 
@@ -180,7 +179,7 @@ def test_array_serialize_missing_optional_nested():
     expected = strip_xml("""
     <root>
         <message>Hello</message>
-        <data />
+        <data/>
     </root>
     """)
 
@@ -366,7 +365,7 @@ def test_array_serialize_primitive_omit_empty():
     expected = strip_xml("""
     <root>
         <value>Hello</value>
-        <value />
+        <value></value>
         <value>Hola</value>
         <value>Bonjour</value>
     </root>
@@ -447,7 +446,7 @@ def test_attribute_serialize():
 
     expected = strip_xml("""
     <root>
-        <element value="Hello, World" />
+        <element value="Hello, World"/>
     </root>
     """)
 
@@ -468,7 +467,7 @@ def test_attribute_serialize_aliased():
 
     expected = strip_xml("""
     <root>
-        <constant value="3.14" />
+        <constant value="3.14"/>
     </root>
     """)
 
@@ -1027,7 +1026,7 @@ def test_primitive_values_serialize_falsey():
         <boolean>False</boolean>
         <float>0.0</float>
         <int>0</int>
-        <string />
+        <string></string>
     </root>
     """)
 
@@ -1053,7 +1052,7 @@ def test_primitive_values_serialize_falsey_omitted():
     ])
 
     expected = strip_xml("""
-    <root />
+    <root/>
     """)
 
     actual = xml.serialize_to_string(processor, value)
@@ -1074,10 +1073,10 @@ def test_primitive_values_serialize_none_default():
 
     expected = strip_xml("""
     <root>
-        <boolean />
-        <float />
-        <int />
-        <string />
+        <boolean></boolean>
+        <float></float>
+        <int></int>
+        <string></string>
     </root>
     """)
 

--- a/tests/test_xpath.py
+++ b/tests/test_xpath.py
@@ -28,8 +28,8 @@ class TestDot(_ProcessorTestCase):
 
     xml_string = strip_xml("""
     <files>
-        <file name="a.txt" size="236" />
-        <file name="b.txt" size="7654" />
+        <file name="a.txt" size="236"/>
+        <file name="b.txt" size="7654"/>
     </files>
     """)
 
@@ -218,9 +218,9 @@ class TestSlashFromRootArray(_ProcessorTestCase):
     xml_string = strip_xml("""
     <locations>
         <cities>
-            <city name="Kansas City" state="MO" />
-            <city name="Lincoln" state="NE" />
-            <city name="Salt Lake City" state="UT" />
+            <city name="Kansas City" state="MO"/>
+            <city name="Lincoln" state="NE"/>
+            <city name="Salt Lake City" state="UT"/>
         </cities>
     </locations>
     """)


### PR DESCRIPTION
lxml is the best Python library for xml.

Currently, there is one usage of minidom for the prettyprint with indent.