### PR TITLE
depend on typing only if Python <= 3.5

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-typing = "*"
+typing = {version = "*", python_version = "<= '3.5'"}
 
 [dev-packages]
 pytest = "==3.8.0"

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     author_email='greg.scott.atkin@gmail.com',
     license='MIT',
     py_modules=['declxml'],
-    install_requires=['typing'],
+    install_requires=['typing; python_version <= "3.5"'],
     data_files=[('', ['py.typed'])],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
Installing typing on Python >= 3.6 causes issues.