### PR TITLE
Fix deprecated license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     author='Greg Atkin',
     author_email='greg.scott.atkin@gmail.com',
     license='MIT',
-    license_files=('LICENSE',)
+    license_files=('LICENSE',),
     py_modules=['declxml'],
     install_requires=['typing'],
     data_files=[('', ['py.typed'])],

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     author='Greg Atkin',
     author_email='greg.scott.atkin@gmail.com',
     license='MIT',
+    license_files=('LICENSE',)
     py_modules=['declxml'],
     install_requires=['typing'],
     data_files=[('', ['py.typed'])],
@@ -34,7 +35,6 @@ setup(
         'Intended Audience :: Developers',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'License :: OSI Approved :: MIT License',
     ],
     keywords='XML, Parsing, Serialization'
 )


### PR DESCRIPTION
Fixes following warning when building:

 setuptools.warnings.SetuptoolsDeprecationWarning: License classifiers
      are deprecated.
      !!


      ********************************************************************************
              Please consider removing the following classifiers in favor of a
      SPDX license expression:

              License :: OSI Approved :: MIT License

              See
      https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license
      for details.

      ********************************************************************************

      !!
